### PR TITLE
Fix incorrect URL in chrome plugin header

### DIFF
--- a/src/hooks/useHost.ts
+++ b/src/hooks/useHost.ts
@@ -4,7 +4,10 @@ export function useHost() {
   return useQuery({
     queryKey: ['host'],
     async queryFn() {
-      const [tab] = await chrome.tabs.query({ active: true })
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        lastFocusedWindow: true
+      })
       if (!tab.url) return null
       return new URL(tab.url).host
     },


### PR DESCRIPTION
If you have multiple windows open in chrome and use `chrome.tabs.query({ active: true })` it will grab the tab from the first window, which may or may not be what is expected. 

Adding `lastFocusedWindow: true` seems to give better results.

## Before:
<img width="395" alt="Screenshot 2023-08-27 at 5 34 15 pm" src="https://github.com/paradigmxyz/rivet/assets/10325/19ffa526-8fcb-48a9-8bd6-514c4918d982">

## After:
<img width="397" alt="Screenshot 2023-08-27 at 5 35 21 pm" src="https://github.com/paradigmxyz/rivet/assets/10325/854e9af5-f0f4-4953-8dde-0bfe49ef204b">

