### PR TITLE
Add `TransactionDetails` screen

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -10,7 +10,7 @@ import { Box, Text } from '~/design-system'
 
 export type TooltipProps = {
   children: ReactNode
-  label: ReactNode
+  label: string | ReactNode
 }
 
 export function Tooltip({ children, label }: TooltipProps) {
@@ -23,7 +23,7 @@ export function Tooltip({ children, label }: TooltipProps) {
           </Box>
         </Trigger>
         <Portal>
-          <Content asChild sideOffset={4}>
+          <Content asChild side="bottom" sideOffset={8}>
             <Box
               backgroundColor="surface/secondary/elevated"
               borderWidth="1px"
@@ -34,7 +34,11 @@ export function Tooltip({ children, label }: TooltipProps) {
               }}
               style={{ cursor: 'text', pointerEvents: 'visible' }}
             >
-              <Text size="11px">{label}</Text>
+              {typeof label !== 'string' ? (
+                label
+              ) : (
+                <Text size="11px">{label}</Text>
+              )}
             </Box>
           </Content>
         </Portal>

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -1,30 +1,33 @@
-import type { Client, GetTransactionParameters, Hash } from "viem";
-import { useClient } from "./useClient";
-import { queryOptions, useQuery } from "@tanstack/react-query";
-import { createQueryKey } from "~/react-query";
+import { useClient } from './useClient'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { Client, GetTransactionParameters, Hash } from 'viem'
+import { createQueryKey } from '~/react-query'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction',
   [key: Client['key'], hash: Hash | (string & {}), deps: string]
 >('transaction')
 
-
-export function useTransactionQueryOptions(args: GetTransactionParameters<'latest'>) {
-    const client = useClient();
-    return queryOptions({
-        queryKey: getTransactionQueryKey([
-            client.key,
-            args.blockHash ||
-            args.blockNumber?.toString() ||
-            args.blockTag || args.hash || 'latest'
-        ]),
-        async queryFn() {
-            return (await client.getTransaction(args)) || null;
-        }
-    })
+export function useTransactionQueryOptions(
+  args: GetTransactionParameters<'latest'>,
+) {
+  const client = useClient()
+  return queryOptions({
+    queryKey: getTransactionQueryKey([
+      client.key,
+      args.blockHash ||
+        args.blockNumber?.toString() ||
+        args.blockTag ||
+        args.hash ||
+        'latest',
+    ]),
+    async queryFn() {
+      return (await client.getTransaction(args)) || null
+    },
+  })
 }
 
 export function useTransaction(args: GetTransactionParameters<'latest'>) {
-    const queryOptions = useTransactionQueryOptions(args);
-    return useQuery(queryOptions);
+  const queryOptions = useTransactionQueryOptions(args)
+  return useQuery(queryOptions)
 }

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -1,0 +1,30 @@
+import type { Client, GetTransactionParameters, Hash } from "viem";
+import { useClient } from "./useClient";
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { createQueryKey } from "~/react-query";
+
+export const getTransactionQueryKey = createQueryKey<
+  'transaction',
+  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+>('transaction')
+
+
+export function useTransactionQueryOptions(args: GetTransactionParameters<'latest'>) {
+    const client = useClient();
+    return queryOptions({
+        queryKey: getTransactionQueryKey([
+            client.key,
+            args.blockHash ||
+            args.blockNumber?.toString() ||
+            args.blockTag || args.hash || 'latest'
+        ]),
+        async queryFn() {
+            return (await client.getTransaction(args)) || null;
+        }
+    })
+}
+
+export function useTransaction(args: GetTransactionParameters<'latest'>) {
+    const queryOptions = useTransactionQueryOptions(args);
+    return useQuery(queryOptions);
+}

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -1,7 +1,7 @@
-import { useClient } from './useClient'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import type { Client, GetTransactionParameters, Hash } from 'viem'
 import { createQueryKey } from '~/react-query'
+import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction',

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -5,7 +5,7 @@ import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction',
-  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+  [key: Client['key'], hash: Hash | (string & {})]
 >('transaction')
 
 export function useTransactionQueryOptions(

--- a/src/hooks/useTransactionConfirmations.ts
+++ b/src/hooks/useTransactionConfirmations.ts
@@ -10,10 +10,10 @@ import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction-confirmations',
-  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+  [key: Client['key'], hash: Hash | (string & {})]
 >('transaction-confirmations')
 
-export function useTransactionReceiptQueryOptions(
+export function useTransactionConfirmationsQueryOptions(
   args: GetTransactionConfirmationsParameters,
 ) {
   const client = useClient()
@@ -31,6 +31,6 @@ export function useTransactionReceiptQueryOptions(
 export function useTransactionConfirmations(
   args: GetTransactionConfirmationsParameters,
 ) {
-  const queryOptions = useTransactionReceiptQueryOptions(args)
+  const queryOptions = useTransactionConfirmationsQueryOptions(args)
   return useQuery(queryOptions)
 }

--- a/src/hooks/useTransactionConfirmations.ts
+++ b/src/hooks/useTransactionConfirmations.ts
@@ -1,0 +1,36 @@
+import { useClient } from './useClient'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import {
+  type Client,
+  type GetTransactionConfirmationsParameters,
+  type Hash,
+  stringify,
+} from 'viem'
+import { createQueryKey } from '~/react-query'
+
+export const getTransactionQueryKey = createQueryKey<
+  'transaction-confirmations',
+  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+>('transaction-confirmations')
+
+export function useTransactionReceiptQueryOptions(
+  args: GetTransactionConfirmationsParameters,
+) {
+  const client = useClient()
+  return queryOptions({
+    queryKey: getTransactionQueryKey([
+      client.key,
+      args.hash || stringify(args),
+    ]),
+    async queryFn() {
+      return (await client.getTransactionConfirmations(args)) || null
+    },
+  })
+}
+
+export function useTransactionConfirmations(
+  args: GetTransactionConfirmationsParameters,
+) {
+  const queryOptions = useTransactionReceiptQueryOptions(args)
+  return useQuery(queryOptions)
+}

--- a/src/hooks/useTransactionConfirmations.ts
+++ b/src/hooks/useTransactionConfirmations.ts
@@ -1,4 +1,3 @@
-import { useClient } from './useClient'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import {
   type Client,
@@ -7,6 +6,7 @@ import {
   stringify,
 } from 'viem'
 import { createQueryKey } from '~/react-query'
+import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction-confirmations',

--- a/src/hooks/useTransactionReceipt.ts
+++ b/src/hooks/useTransactionReceipt.ts
@@ -1,7 +1,7 @@
-import { useClient } from './useClient'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import type { Client, GetTransactionReceiptParameters, Hash } from 'viem'
 import { createQueryKey } from '~/react-query'
+import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction-receipt',

--- a/src/hooks/useTransactionReceipt.ts
+++ b/src/hooks/useTransactionReceipt.ts
@@ -1,0 +1,26 @@
+import { useClient } from './useClient'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { Client, GetTransactionReceiptParameters, Hash } from 'viem'
+import { createQueryKey } from '~/react-query'
+
+export const getTransactionQueryKey = createQueryKey<
+  'transaction-receipt',
+  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+>('transaction-receipt')
+
+export function useTransactionReceiptQueryOptions(
+  args: GetTransactionReceiptParameters,
+) {
+  const client = useClient()
+  return queryOptions({
+    queryKey: getTransactionQueryKey([client.key, args.hash]),
+    async queryFn() {
+      return (await client.getTransactionReceipt(args)) || null
+    },
+  })
+}
+
+export function useTransactionReceipt(args: GetTransactionReceiptParameters) {
+  const queryOptions = useTransactionReceiptQueryOptions(args)
+  return useQuery(queryOptions)
+}

--- a/src/hooks/useTransactionReceipt.ts
+++ b/src/hooks/useTransactionReceipt.ts
@@ -5,7 +5,7 @@ import { useClient } from './useClient'
 
 export const getTransactionQueryKey = createQueryKey<
   'transaction-receipt',
-  [key: Client['key'], hash: Hash | (string & {}), deps: string]
+  [key: Client['key'], hash: Hash | (string & {})]
 >('transaction-receipt')
 
 export function useTransactionReceiptQueryOptions(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import {
   useSessionsStore,
 } from '~/zustand'
 
+import TransactionDetails from './screens/TransactionDetails'
 import Layout from './screens/_layout'
 import AccountConfig from './screens/account-config'
 import BlockConfig from './screens/block-config'
@@ -57,7 +58,20 @@ const router = createHashRouter([
       },
       {
         path: 'block/:blockNumber',
-        element: <BlockDetails />,
+        children: [
+          {
+            path: '',
+            element: <BlockDetails />,
+          },
+          {
+            path: 'transaction/:transactionHash',
+            element: <TransactionDetails />,
+          },
+        ],
+      },
+      {
+        path: 'transaction/:transactionHash',
+        element: <TransactionDetails />,
       },
       {
         path: 'network-config',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,16 +58,7 @@ const router = createHashRouter([
       },
       {
         path: 'block/:blockNumber',
-        children: [
-          {
-            path: '',
-            element: <BlockDetails />,
-          },
-          {
-            path: 'transaction/:transactionHash',
-            element: <TransactionDetails />,
-          },
-        ],
+        element: <BlockDetails />,
       },
       {
         path: 'transaction/:transactionHash',

--- a/src/screens/TransactionDetails.tsx
+++ b/src/screens/TransactionDetails.tsx
@@ -1,0 +1,206 @@
+import { useParams } from 'react-router-dom'
+import { type Hash, formatEther, formatGwei } from 'viem'
+import { Container, LabelledContent } from '~/components'
+import { Column, Columns, Separator, Stack, Text } from '~/design-system'
+import { useTransaction } from '~/hooks/useTransaction'
+import { useTransactionConfirmations } from '~/hooks/useTransactionConfirmations'
+import { useTransactionReceipt } from '~/hooks/useTransactionReceipt'
+import { truncate } from '~/utils'
+
+const numberIntl = new Intl.NumberFormat()
+const numberIntl4SigFigs = new Intl.NumberFormat('en-US', {
+  maximumSignificantDigits: 4,
+})
+
+export default function TransactionDetails() {
+  const { transactionHash } = useParams()
+
+  const { data: transaction } = useTransaction({
+    hash: transactionHash as Hash,
+  })
+
+  const { data: receipt } = useTransactionReceipt({
+    hash: transaction?.hash as Hash,
+  })
+
+  const { data: confirmations } = useTransactionConfirmations({
+    hash: receipt?.transactionHash as Hash,
+  })
+
+  if (!transaction) return null
+
+  return (
+    <>
+      <Container
+        dismissable
+        header={`Transaction ${truncate(transaction.hash, { start: 4 })}`}
+      >
+        <Stack gap="20px">
+          <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="Hash">
+                <Text size="12px">
+                  {truncate(transaction.hash!.toString(), { start: 8 })}
+                </Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="Status">
+                {receipt?.status === undefined ? (
+                  <Text color="text/tertiary" size="12px">
+                    Pending
+                  </Text>
+                ) : (
+                  <Text size="12px">{receipt?.status}</Text>
+                )}
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="Nonce">
+                <Text size="12px">{transaction.nonce}</Text>
+              </LabelledContent>
+            </Column>
+          </Columns>
+          <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="From">
+                <Text size="12px">
+                  {truncate(transaction.from, { start: 4 })}
+                </Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="To">
+                <Text size="12px">
+                  {truncate(
+                    transaction.to
+                      ? transaction.to
+                      : '0x0000000000000000000000000000000000000000',
+                    { start: 4 },
+                  )}
+                </Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="Value">
+                <Text size="12px">
+                  {numberIntl4SigFigs.format(
+                    Number(formatEther(transaction.value!)),
+                  )}{' '}
+                  ETH
+                </Text>
+              </LabelledContent>
+            </Column>
+          </Columns>
+          <Separator />
+          <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="Gas">
+                <Text size="12px">{transaction.gas.toString()}</Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="Base Fee">
+                <Text size="12px">
+                  {numberIntl.format(Number(formatGwei(transaction.gasPrice!)))}{' '}
+                  gwei
+                </Text>
+              </LabelledContent>
+            </Column>
+            {receipt?.gasUsed ? (
+              <Column width="1/3">
+                <LabelledContent label="Gas Used">
+                  <Text size="12px">{receipt?.gasUsed.toString()}</Text>
+                </LabelledContent>
+              </Column>
+            ) : null}
+          </Columns>
+          {receipt && (
+            <>
+              <Columns gap="12px">
+                <Column width="1/3">
+                  <LabelledContent label="type">
+                    <Text size="12px">{receipt.type}</Text>
+                  </LabelledContent>
+                </Column>
+                <Column>
+                  <LabelledContent label="cumulative gas used">
+                    <Text size="12px">
+                      {receipt.cumulativeGasUsed.toString()}
+                    </Text>
+                  </LabelledContent>
+                </Column>
+                <Column>
+                  <LabelledContent label="effective gas price">
+                    <Text size="12px">
+                      {receipt.effectiveGasPrice.toString()}
+                    </Text>
+                  </LabelledContent>
+                </Column>
+              </Columns>
+              <Separator />
+              <Columns gap="12px">
+                <Column width="1/3">
+                  <LabelledContent label="Block">
+                    <Text size="12px">{receipt.blockNumber.toString()}</Text>
+                  </LabelledContent>
+                </Column>
+                <Column width="1/3">
+                  <LabelledContent label="Block Hash">
+                    <Text size="12px">
+                      {truncate(receipt.blockHash, { start: 4 })}
+                    </Text>
+                  </LabelledContent>
+                </Column>
+                <Column width="1/3">
+                  <LabelledContent label="Index">
+                    <Text size="12px">{receipt.transactionIndex}</Text>
+                  </LabelledContent>
+                </Column>
+              </Columns>
+            </>
+          )}
+          <Separator />
+          <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="v">
+                <Text size="12px">{transaction.v.toString()}</Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="r">
+                <Text size="12px">{truncate(transaction.r, { start: 4 })}</Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="s">
+                <Text size="12px">{truncate(transaction.s, { start: 4 })}</Text>
+              </LabelledContent>
+            </Column>
+          </Columns>
+          <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="Confirmations">
+                <Text size="12px">{confirmations?.toString()}</Text>
+              </LabelledContent>
+            </Column>
+          </Columns>
+          <Columns gap="12px">
+            <Column>
+              <LabelledContent label="input data">
+                <Text
+                  style={{ wordBreak: 'break-all' }}
+                  wrap={false}
+                  width="full"
+                  size="12px"
+                >
+                  {transaction.input}
+                </Text>
+              </LabelledContent>
+            </Column>
+          </Columns>
+        </Stack>
+      </Container>
+    </>
+  )
+}

--- a/src/screens/TransactionDetails.tsx
+++ b/src/screens/TransactionDetails.tsx
@@ -1,11 +1,12 @@
 import { useParams } from 'react-router-dom'
 import { type Hash, formatEther, formatGwei } from 'viem'
-import { Container, LabelledContent } from '~/components'
+import { Container, LabelledContent, Tooltip } from '~/components'
 import { Column, Columns, Separator, Stack, Text } from '~/design-system'
+import { useBlock } from '~/hooks/useBlock'
 import { useTransaction } from '~/hooks/useTransaction'
 import { useTransactionConfirmations } from '~/hooks/useTransactionConfirmations'
 import { useTransactionReceipt } from '~/hooks/useTransactionReceipt'
-import { truncate } from '~/utils'
+import { capitalize, truncate } from '~/utils'
 
 const numberIntl = new Intl.NumberFormat()
 const numberIntl4SigFigs = new Intl.NumberFormat('en-US', {
@@ -18,30 +19,30 @@ export default function TransactionDetails() {
   const { data: transaction } = useTransaction({
     hash: transactionHash as Hash,
   })
-
   const { data: receipt } = useTransactionReceipt({
     hash: transaction?.hash as Hash,
   })
-
   const { data: confirmations } = useTransactionConfirmations({
     hash: receipt?.transactionHash as Hash,
   })
+  const { data: block } = useBlock({ blockNumber: transaction?.blockNumber })
 
   if (!transaction) return null
-
   return (
     <>
       <Container
         dismissable
-        header={`Transaction ${truncate(transaction.hash, { start: 4 })}`}
+        header={`Transaction ${truncate(transaction.hash, { start: 8 })}`}
       >
         <Stack gap="20px">
           <Columns gap="12px">
             <Column width="1/3">
               <LabelledContent label="Hash">
-                <Text size="12px">
-                  {truncate(transaction.hash!.toString(), { start: 8 })}
-                </Text>
+                <Tooltip label={<Text size="9px">{transaction.hash}</Text>}>
+                  <Text size="12px">
+                    {truncate(transaction.hash!.toString(), { start: 8 })}
+                  </Text>
+                </Tooltip>
               </LabelledContent>
             </Column>
             <Column width="1/3">
@@ -51,7 +52,7 @@ export default function TransactionDetails() {
                     Pending
                   </Text>
                 ) : (
-                  <Text size="12px">{receipt?.status}</Text>
+                  <Text size="12px">{capitalize(receipt?.status)}</Text>
                 )}
               </LabelledContent>
             </Column>
@@ -64,21 +65,22 @@ export default function TransactionDetails() {
           <Columns gap="12px">
             <Column width="1/3">
               <LabelledContent label="From">
-                <Text size="12px">
-                  {truncate(transaction.from, { start: 4 })}
-                </Text>
+                <Tooltip label={transaction.from}>
+                  <Text size="12px">
+                    {truncate(transaction.from, { start: 4 })}
+                  </Text>
+                </Tooltip>
               </LabelledContent>
             </Column>
             <Column width="1/3">
               <LabelledContent label="To">
-                <Text size="12px">
-                  {truncate(
-                    transaction.to
-                      ? transaction.to
-                      : '0x0000000000000000000000000000000000000000',
-                    { start: 4 },
-                  )}
-                </Text>
+                <Tooltip label={transaction.to}>
+                  <Text size="12px">
+                    {transaction.to
+                      ? truncate(transaction.to, { start: 4 })
+                      : null}
+                  </Text>
+                </Tooltip>
               </LabelledContent>
             </Column>
             <Column width="1/3">
@@ -93,109 +95,150 @@ export default function TransactionDetails() {
             </Column>
           </Columns>
           <Separator />
-          <Columns gap="12px">
-            <Column width="1/3">
-              <LabelledContent label="Gas">
-                <Text size="12px">{transaction.gas.toString()}</Text>
-              </LabelledContent>
-            </Column>
-            <Column width="1/3">
-              <LabelledContent label="Base Fee">
-                <Text size="12px">
-                  {numberIntl.format(Number(formatGwei(transaction.gasPrice!)))}{' '}
-                  gwei
-                </Text>
-              </LabelledContent>
-            </Column>
-            {receipt?.gasUsed ? (
-              <Column width="1/3">
-                <LabelledContent label="Gas Used">
-                  <Text size="12px">{receipt?.gasUsed.toString()}</Text>
-                </LabelledContent>
-              </Column>
-            ) : null}
-          </Columns>
-          {receipt && (
+          {block?.timestamp ? (
             <>
               <Columns gap="12px">
                 <Column width="1/3">
-                  <LabelledContent label="type">
-                    <Text size="12px">{receipt.type}</Text>
+                  <LabelledContent label="Block">
+                    <Stack gap="6px">
+                      <Text size="12px">{receipt?.blockNumber.toString()}</Text>
+                      <Text color="text/tertiary" size="9px">
+                        {confirmations?.toString()} Confirmations
+                      </Text>
+                    </Stack>
                   </LabelledContent>
                 </Column>
                 <Column>
-                  <LabelledContent label="cumulative gas used">
+                  <LabelledContent label="Timestamp">
                     <Text size="12px">
-                      {receipt.cumulativeGasUsed.toString()}
-                    </Text>
-                  </LabelledContent>
-                </Column>
-                <Column>
-                  <LabelledContent label="effective gas price">
-                    <Text size="12px">
-                      {receipt.effectiveGasPrice.toString()}
+                      {new Date(
+                        Number(block?.timestamp! * 1000n),
+                      ).toLocaleString()}
                     </Text>
                   </LabelledContent>
                 </Column>
               </Columns>
               <Separator />
-              <Columns gap="12px">
-                <Column width="1/3">
-                  <LabelledContent label="Block">
-                    <Text size="12px">{receipt.blockNumber.toString()}</Text>
-                  </LabelledContent>
-                </Column>
-                <Column width="1/3">
-                  <LabelledContent label="Block Hash">
-                    <Text size="12px">
-                      {truncate(receipt.blockHash, { start: 4 })}
-                    </Text>
-                  </LabelledContent>
-                </Column>
-                <Column width="1/3">
-                  <LabelledContent label="Index">
-                    <Text size="12px">{receipt.transactionIndex}</Text>
-                  </LabelledContent>
-                </Column>
-              </Columns>
             </>
-          )}
+          ) : null}
+          <Columns gap="12px">
+            <Column width="1/4">
+              <LabelledContent label="Type">
+                <Text size="12px">{transaction.type}</Text>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              {transaction.type === 'eip1559' ? (
+                <LabelledContent label="Tip/Max Fee Per Gas">
+                  <Text size="12px">
+                    {transaction.maxPriorityFeePerGas
+                      ? `${numberIntl.format(
+                          Number(formatGwei(transaction.maxPriorityFeePerGas)),
+                        )}`
+                      : null}
+                    /
+                    {transaction.maxFeePerGas
+                      ? `${numberIntl.format(
+                          Number(formatGwei(transaction.maxFeePerGas)),
+                        )}`
+                      : null}{' '}
+                    gwei
+                  </Text>
+                </LabelledContent>
+              ) : (
+                <LabelledContent label="Gas Price">
+                  <Text size="12px">
+                    {transaction.gasPrice
+                      ? `${numberIntl.format(
+                          Number(formatGwei(transaction.gasPrice)),
+                        )} gwei`
+                      : null}
+                  </Text>
+                </LabelledContent>
+              )}
+            </Column>
+            {receipt && transaction.type === 'eip1559' && (
+              <Column width="1/3">
+                <LabelledContent label="Actual Fee Per Gas">
+                  <Text size="12px">
+                    {receipt.effectiveGasPrice
+                      ? `${numberIntl.format(
+                          Number(formatGwei(receipt.effectiveGasPrice)),
+                        )} gwei`
+                      : null}
+                  </Text>
+                </LabelledContent>
+              </Column>
+            )}
+          </Columns>
+          <Columns gap="12px">
+            <Column width="1/4">
+              <LabelledContent label="Gas">
+                <Text size="12px">{transaction.gas.toString()}</Text>
+              </LabelledContent>
+            </Column>
+            {receipt?.gasUsed ? (
+              <Column>
+                <LabelledContent label="Gas Used/Limit">
+                  <Text size="12px">
+                    {numberIntl.format(Number(receipt.gasUsed?.toString()))} /{' '}
+                    {numberIntl.format(Number(transaction.gas?.toString()))} (
+                    {Math.round(
+                      (Number(receipt.gasUsed) / Number(transaction.gas)) * 100,
+                    )}
+                    %)
+                  </Text>
+                </LabelledContent>
+              </Column>
+            ) : null}
+            {receipt?.effectiveGasPrice && receipt?.gasUsed ? (
+              <Column width="1/3">
+                <LabelledContent label="Fee">
+                  <Text size="12px">
+                    {numberIntl4SigFigs.format(
+                      Number(
+                        formatEther(
+                          receipt?.effectiveGasPrice * receipt?.gasUsed,
+                        ),
+                      ),
+                    )}{' '}
+                    ETH
+                  </Text>
+                </LabelledContent>
+              </Column>
+            ) : null}
+          </Columns>
           <Separator />
           <Columns gap="12px">
+            <Column width="1/3">
+              <LabelledContent label="r">
+                <Tooltip label={<Text size="9px">{transaction.r}</Text>}>
+                  <Text size="12px">
+                    {truncate(transaction.r, { start: 4 })}
+                  </Text>
+                </Tooltip>
+              </LabelledContent>
+            </Column>
+            <Column width="1/3">
+              <LabelledContent label="s">
+                <Tooltip label={<Text size="9px">{transaction.s}</Text>}>
+                  <Text size="12px">
+                    {truncate(transaction.s, { start: 4 })}
+                  </Text>
+                </Tooltip>
+              </LabelledContent>
+            </Column>
             <Column width="1/3">
               <LabelledContent label="v">
                 <Text size="12px">{transaction.v.toString()}</Text>
               </LabelledContent>
             </Column>
-            <Column width="1/3">
-              <LabelledContent label="r">
-                <Text size="12px">{truncate(transaction.r, { start: 4 })}</Text>
-              </LabelledContent>
-            </Column>
-            <Column width="1/3">
-              <LabelledContent label="s">
-                <Text size="12px">{truncate(transaction.s, { start: 4 })}</Text>
-              </LabelledContent>
-            </Column>
           </Columns>
-          <Columns gap="12px">
-            <Column width="1/3">
-              <LabelledContent label="Confirmations">
-                <Text size="12px">{confirmations?.toString()}</Text>
-              </LabelledContent>
-            </Column>
-          </Columns>
+          <Separator />
           <Columns gap="12px">
             <Column>
-              <LabelledContent label="input data">
-                <Text
-                  style={{ wordBreak: 'break-all' }}
-                  wrap={false}
-                  width="full"
-                  size="12px"
-                >
-                  {transaction.input}
-                </Text>
+              <LabelledContent label="Calldata">
+                <Text size="12px">{transaction.input}</Text>
               </LabelledContent>
             </Column>
           </Columns>

--- a/src/screens/block-details.tsx
+++ b/src/screens/block-details.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react'
-import { useParams, useSearchParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 
 import { type Transaction, formatEther, formatGwei } from 'viem'
 import { Container, LabelledContent, Tooltip } from '~/components'
@@ -140,52 +140,54 @@ export default function BlockDetails() {
                     (transaction, i) => (
                       <Fragment key={transaction.hash}>
                         {i !== 0 && <Separator />}
-                        <Box paddingHorizontal="12px" paddingVertical="8px">
-                          <Columns alignVertical="center">
-                            <LabelledContent label="Hash">
-                              <Inline
-                                alignVertical="center"
-                                gap="4px"
-                                wrap={false}
-                              >
-                                <Tooltip label={transaction.hash}>
-                                  <Text size="12px">
-                                    {truncate(transaction.hash, { start: 4 })}
-                                  </Text>
-                                </Tooltip>
-                              </Inline>
-                            </LabelledContent>
-                            <LabelledContent label="From">
-                              <Tooltip label={transaction.from}>
-                                <Text wrap={false} size="12px">
-                                  {truncate(transaction.from, {
-                                    start: 6,
-                                    end: 4,
-                                  })}
-                                </Text>
-                              </Tooltip>
-                            </LabelledContent>
-                            <LabelledContent label="To">
-                              <Tooltip label={transaction.to}>
-                                <Text wrap={false} size="12px">
-                                  {transaction.to &&
-                                    truncate(transaction.to, {
+                        <Link to={`transaction/${transaction.hash}`}>
+                          <Box paddingHorizontal="12px" paddingVertical="8px">
+                            <Columns alignVertical="center">
+                              <LabelledContent label="Hash">
+                                <Inline
+                                  alignVertical="center"
+                                  gap="4px"
+                                  wrap={false}
+                                >
+                                  <Tooltip label={transaction.hash}>
+                                    <Text size="12px">
+                                      {truncate(transaction.hash, { start: 4 })}
+                                    </Text>
+                                  </Tooltip>
+                                </Inline>
+                              </LabelledContent>
+                              <LabelledContent label="From">
+                                <Tooltip label={transaction.from}>
+                                  <Text wrap={false} size="12px">
+                                    {truncate(transaction.from, {
                                       start: 6,
                                       end: 4,
                                     })}
+                                  </Text>
+                                </Tooltip>
+                              </LabelledContent>
+                              <LabelledContent label="To">
+                                <Tooltip label={transaction.to}>
+                                  <Text wrap={false} size="12px">
+                                    {transaction.to &&
+                                      truncate(transaction.to, {
+                                        start: 6,
+                                        end: 4,
+                                      })}
+                                  </Text>
+                                </Tooltip>
+                              </LabelledContent>
+                              <LabelledContent label="Value">
+                                <Text wrap={false} size="12px">
+                                  {numberIntl4SigFigs.format(
+                                    Number(formatEther(transaction.value!)),
+                                  )}{' '}
+                                  ETH
                                 </Text>
-                              </Tooltip>
-                            </LabelledContent>
-                            <LabelledContent label="Value">
-                              <Text wrap={false} size="12px">
-                                {numberIntl4SigFigs.format(
-                                  Number(formatEther(transaction.value!)),
-                                )}{' '}
-                                ETH
-                              </Text>
-                            </LabelledContent>
-                          </Columns>
-                        </Box>
+                              </LabelledContent>
+                            </Columns>
+                          </Box>
+                        </Link>
                       </Fragment>
                     ),
                   )}

--- a/src/screens/block-details.tsx
+++ b/src/screens/block-details.tsx
@@ -140,8 +140,14 @@ export default function BlockDetails() {
                     (transaction, i) => (
                       <Fragment key={transaction.hash}>
                         {i !== 0 && <Separator />}
-                        <Link to={`transaction/${transaction.hash}`}>
-                          <Box paddingHorizontal="12px" paddingVertical="8px">
+                        <Link to={`/transaction/${transaction.hash}`}>
+                          <Box
+                            backgroundColor={{
+                              hover: 'surface/fill/quarternary',
+                            }}
+                            paddingHorizontal="12px"
+                            paddingVertical="8px"
+                          >
                             <Columns alignVertical="center">
                               <LabelledContent label="Hash">
                                 <Inline

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -503,64 +503,66 @@ function Transactions() {
           const { transaction, status } = transactions[index] || {}
           if (!transaction || typeof transaction === 'string') return
           return (
-            <Box
-              key={key}
-              backgroundColor={{ hover: 'surface/fill/quarternary' }}
-              position="absolute"
-              top="0px"
-              left="0px"
-              width="full"
-              style={{
-                height: `${size}px`,
-                transform: `translateY(${start}px)`,
-              }}
-            >
-              <Box paddingHorizontal="12px" paddingVertical="8px">
-                <Columns alignVertical="center">
-                  <LabelledContent label="Block">
-                    <Inline alignVertical="center" gap="4px" wrap={false}>
-                      <Text size="12px">
-                        {transaction.blockNumber?.toString()}
-                      </Text>
-                      {status === 'pending' && (
-                        <SFSymbol
-                          color="text/tertiary"
-                          size="11px"
-                          symbol="clock"
-                          weight="semibold"
-                        />
-                      )}
-                    </Inline>
-                  </LabelledContent>
-                  <LabelledContent label="From">
-                    <Tooltip label={transaction.from}>
+            <Link to={`transaction/${transaction.hash}`}>
+              <Box
+                key={key}
+                backgroundColor={{ hover: 'surface/fill/quarternary' }}
+                position="absolute"
+                top="0px"
+                left="0px"
+                width="full"
+                style={{
+                  height: `${size}px`,
+                  transform: `translateY(${start}px)`,
+                }}
+              >
+                <Box paddingHorizontal="12px" paddingVertical="8px">
+                  <Columns alignVertical="center">
+                    <LabelledContent label="Block">
+                      <Inline alignVertical="center" gap="4px" wrap={false}>
+                        <Text size="12px">
+                          {transaction.blockNumber?.toString()}
+                        </Text>
+                        {status === 'pending' && (
+                          <SFSymbol
+                            color="text/tertiary"
+                            size="11px"
+                            symbol="clock"
+                            weight="semibold"
+                          />
+                        )}
+                      </Inline>
+                    </LabelledContent>
+                    <LabelledContent label="From">
+                      <Tooltip label={transaction.from}>
+                        <Text wrap={false} size="12px">
+                          {truncate(transaction.from, { start: 6, end: 4 })}
+                        </Text>
+                      </Tooltip>
+                    </LabelledContent>
+                    <LabelledContent label="To">
+                      <Tooltip label={transaction.to}>
+                        <Text wrap={false} size="12px">
+                          {transaction.to &&
+                            truncate(transaction.to, { start: 6, end: 4 })}
+                        </Text>
+                      </Tooltip>
+                    </LabelledContent>
+                    <LabelledContent label="Value">
                       <Text wrap={false} size="12px">
-                        {truncate(transaction.from, { start: 6, end: 4 })}
+                        {numberIntl4SigFigs.format(
+                          Number(formatEther(transaction.value!)),
+                        )}{' '}
+                        ETH
                       </Text>
-                    </Tooltip>
-                  </LabelledContent>
-                  <LabelledContent label="To">
-                    <Tooltip label={transaction.to}>
-                      <Text wrap={false} size="12px">
-                        {transaction.to &&
-                          truncate(transaction.to, { start: 6, end: 4 })}
-                      </Text>
-                    </Tooltip>
-                  </LabelledContent>
-                  <LabelledContent label="Value">
-                    <Text wrap={false} size="12px">
-                      {numberIntl4SigFigs.format(
-                        Number(formatEther(transaction.value!)),
-                      )}{' '}
-                      ETH
-                    </Text>
-                  </LabelledContent>
-                </Columns>
+                    </LabelledContent>
+                  </Columns>
+                </Box>
+                <Box marginHorizontal="-12px">
+                  <Separator />
+                </Box>
               </Box>
-              <Box marginHorizontal="-12px">
-                <Separator />
-              </Box>
-            </Box>
+            </Link>
           )
         })}
       </Box>

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -503,7 +503,7 @@ function Transactions() {
           const { transaction, status } = transactions[index] || {}
           if (!transaction || typeof transaction === 'string') return
           return (
-            <Link to={`transaction/${transaction.hash}`}>
+            <Link to={`/transaction/${transaction.hash}`}>
               <Box
                 key={key}
                 backgroundColor={{ hover: 'surface/fill/quarternary' }}

--- a/src/utils/capitalize.ts
+++ b/src/utils/capitalize.ts
@@ -1,0 +1,2 @@
+export const capitalize = (str: string) =>
+  `${str.charAt(0).toUpperCase()}${str.slice(1).toLowerCase()}`

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { capitalize } from './capitalize'
 export { deepEqual } from './deepEqual'
 export { truncate } from './truncate'
 export { uid } from './uid'


### PR DESCRIPTION
- [x] `useTransaction` hook
- [x] `useTransactionReceipt` hook
- [x] `useTransactionConfirmations` hook
- [x] Add `TransactionDetails` `Link` to `block-details` screen
- [x] Add `TransactionDetails` `Link` to transactions tab
- [ ] `input data` wrapping
- [ ] `Link` from transactions to blocks (problem hash router)
- [ ] Transaction logs (I propose tabs in the transaction view)

You can see in the below screenshot that I am trying to go from transaction to a block (check url at bottom left corner), but to achieve this I will have to nest in the routes (is that the right way?)

<img width="1439" alt="image" src="https://github.com/paradigmxyz/rivet/assets/38040789/a4746504-b364-4920-aae9-336948fcefb0">

<img width="764" alt="image" src="https://github.com/paradigmxyz/rivet/assets/38040789/bbb1ecb0-469e-42d0-bcec-9a91f573b869">

