### PR TITLE
Add list of sessions

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -140,8 +140,8 @@ function Account() {
 
 function DappConnection() {
   const { data: host } = useHost()
-  const { sessions } = useSessionsStore()
-  const isConnected = Boolean(host && sessions[host])
+  const { getSession } = useSessionsStore()
+  const isConnected = Boolean(host && getSession({ host }))
 
   return (
     <Link to="session" style={{ height: '100%' }}>

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -26,12 +26,12 @@ export function getProvider({
   let _id = Math.floor(Math.random() * 10000)
 
   messenger.reply('accountsChanged', async ({ accounts, sessions }) => {
-    if (host && !sessions[host]) return
+    if (host && !sessions.find((session) => session.host === host)) return
     emitter.emit('accountsChanged', accounts)
   })
 
   messenger.reply('chainChanged', async ({ chainId, sessions }) => {
-    if (host && !sessions[host]) return
+    if (host && !sessions.find((session) => session.host === host)) return
     emitter.emit('chainChanged', chainId)
   })
 

--- a/src/screens/session.tsx
+++ b/src/screens/session.tsx
@@ -1,7 +1,15 @@
 import { Fragment } from 'react'
 import { connect, disconnect } from '~/actions'
 import { Container, LabelledContent } from '~/components'
-import { Box, Button, Separator, Stack, Text } from '~/design-system'
+import {
+  Box,
+  Button,
+  Inline,
+  SFSymbol,
+  Separator,
+  Stack,
+  Text,
+} from '~/design-system'
 import { useHost } from '~/hooks/useHost'
 import { getMessenger } from '~/messengers'
 import { useSessionsStore } from '~/zustand'
@@ -44,9 +52,32 @@ export default function Session() {
             {Object.values(sessions).map((session) => {
               return (
                 <Fragment key={session.host}>
-                  <LabelledContent label="Host" width="fit">
-                    <Text size="12px">{session.host}</Text>
-                  </LabelledContent>
+                  <Inline
+                    alignVertical="center"
+                    alignHorizontal="justify"
+                    wrap={false}
+                  >
+                    <LabelledContent label="Host" width="fit">
+                      <Text size="12px">{session.host}</Text>
+                    </LabelledContent>
+                    <Box
+                      cursor="pointer"
+                      width="fit"
+                      onClick={() => {
+                        disconnect({
+                          host: session.host,
+                          messenger: inpageMessenger,
+                        })
+                      }}
+                    >
+                      <SFSymbol
+                        color="text/tertiary"
+                        size="12px"
+                        symbol="trash"
+                        weight="medium"
+                      />
+                    </Box>
+                  </Inline>
                   <Separator />
                 </Fragment>
               )

--- a/src/screens/session.tsx
+++ b/src/screens/session.tsx
@@ -1,6 +1,7 @@
+import { Fragment } from 'react'
 import { connect, disconnect } from '~/actions'
-import { Container } from '~/components'
-import { Box, Button } from '~/design-system'
+import { Container, LabelledContent } from '~/components'
+import { Box, Button, Separator, Stack, Text } from '~/design-system'
 import { useHost } from '~/hooks/useHost'
 import { getMessenger } from '~/messengers'
 import { useSessionsStore } from '~/zustand'
@@ -9,8 +10,9 @@ const inpageMessenger = getMessenger('wallet:inpage')
 
 export default function Session() {
   const { data: host } = useHost()
-  const { sessions } = useSessionsStore()
-  const isConnected = Boolean(host && sessions[host])
+  const { getSession, getSessions } = useSessionsStore()
+  const sessions = getSessions()
+  const isConnected = Boolean(host && getSession({ host }))
 
   return (
     <>
@@ -39,7 +41,18 @@ export default function Session() {
       </Box>
       <Box>
         <Container fit header="Sessions">
-          TODO
+          <Stack gap="16px">
+            {Object.values(sessions).map((session) => {
+              return (
+                <Fragment key={session.host}>
+                  <LabelledContent label="Host" width="fit">
+                    <Text size="12px">{session.host}</Text>
+                  </LabelledContent>
+                  <Separator />
+                </Fragment>
+              )
+            })}
+          </Stack>
         </Container>
       </Box>
     </>

--- a/src/screens/session.tsx
+++ b/src/screens/session.tsx
@@ -10,9 +10,8 @@ const inpageMessenger = getMessenger('wallet:inpage')
 
 export default function Session() {
   const { data: host } = useHost()
-  const { getSession, getSessions } = useSessionsStore()
-  const sessions = getSessions()
-  const isConnected = Boolean(host && getSession({ host }))
+  const { sessions } = useSessionsStore()
+  const isConnected = Boolean(host && sessions[host])
 
   return (
     <>

--- a/src/screens/session.tsx
+++ b/src/screens/session.tsx
@@ -18,8 +18,8 @@ const inpageMessenger = getMessenger('wallet:inpage')
 
 export default function Session() {
   const { data: host } = useHost()
-  const { sessions } = useSessionsStore()
-  const isConnected = Boolean(host && sessions[host])
+  const { getSession, sessions } = useSessionsStore()
+  const isConnected = Boolean(host && getSession({ host }))
 
   return (
     <>

--- a/src/zustand/sessions.ts
+++ b/src/zustand/sessions.ts
@@ -11,6 +11,7 @@ export type SessionsState = {
 export type SessionsActions = {
   addSession: ({ session }: { session: Session }) => void
   getSession: ({ host }: { host: Host }) => Session
+  getSessions: () => Session[]
   removeSession: ({ host }: { host: Host }) => void
 }
 export type SessionsStore = SessionsState & SessionsActions
@@ -29,6 +30,9 @@ export const sessionsStore = createStore<SessionsStore>(
     },
     getSession({ host }) {
       return get().sessions[host]
+    },
+    getSessions() {
+      return Object.values(get().sessions)
     },
     removeSession({ host }) {
       set((state) => {

--- a/src/zustand/sessions.ts
+++ b/src/zustand/sessions.ts
@@ -11,7 +11,6 @@ export type SessionsState = {
 export type SessionsActions = {
   addSession: ({ session }: { session: Session }) => void
   getSession: ({ host }: { host: Host }) => Session
-  getSessions: () => Session[]
   removeSession: ({ host }: { host: Host }) => void
 }
 export type SessionsStore = SessionsState & SessionsActions
@@ -30,9 +29,6 @@ export const sessionsStore = createStore<SessionsStore>(
     },
     getSession({ host }) {
       return get().sessions[host]
-    },
-    getSessions() {
-      return Object.values(get().sessions)
     },
     removeSession({ host }) {
       set((state) => {

--- a/src/zustand/sessions.ts
+++ b/src/zustand/sessions.ts
@@ -6,33 +6,32 @@ type Host = string
 type Session = { host: Host }
 
 export type SessionsState = {
-  sessions: Record<Host, Session>
+  sessions: Session[]
 }
 export type SessionsActions = {
   addSession: ({ session }: { session: Session }) => void
-  getSession: ({ host }: { host: Host }) => Session
+  getSession: ({ host }: { host: Host }) => Session | undefined
   removeSession: ({ host }: { host: Host }) => void
 }
 export type SessionsStore = SessionsState & SessionsActions
 
 export const sessionsStore = createStore<SessionsStore>(
   (set, get) => ({
-    sessions: {},
+    sessions: [],
     addSession({ session }) {
       set((state) => ({
         ...state,
-        sessions: {
-          ...state.sessions,
-          [session.host]: session,
-        },
+        sessions: [...state.sessions, session],
       }))
     },
     getSession({ host }) {
-      return get().sessions[host]
+      return get().sessions.find((session) => session.host === host)
     },
     removeSession({ host }) {
       set((state) => {
-        const { [host]: _, ...sessions } = state.sessions
+        const sessions = state.sessions.filter(
+          (session) => session.host !== host,
+        )
         return {
           ...state,
           sessions,


### PR DESCRIPTION
Update:
Lists all sessions on the sessions screen, and includes a delete button to remove sessions.

<img width="401" alt="image" src="https://github.com/paradigmxyz/rivet/assets/656107/bbbbd79b-5329-4427-a316-57e863d3aedb">


~~Adds a `getSessions` action to the session store & lists all sessions on the sessions screen~~

~~I wanted to add a delete-button to remove sessions to the list as well, but when I did that the component didn't re-render properly after removing a session. I tried debugging it for a bit but I'm not super familiar with zustand so I decided to open a first PR without it~~

Closes #12