### PR TITLE
Fix duplicated session

### DIFF
--- a/src/zustand/sessions.ts
+++ b/src/zustand/sessions.ts
@@ -19,6 +19,9 @@ export const sessionsStore = createStore<SessionsStore>(
   (set, get) => ({
     sessions: [],
     addSession({ session }) {
+      if (get().sessions.find((s) => s.host === session.host)) {
+        return
+      }
       set((state) => ({
         ...state,
         sessions: [...state.sessions, session],

--- a/src/zustand/sessions.ts
+++ b/src/zustand/sessions.ts
@@ -19,9 +19,7 @@ export const sessionsStore = createStore<SessionsStore>(
   (set, get) => ({
     sessions: [],
     addSession({ session }) {
-      if (get().sessions.find((s) => s.host === session.host)) {
-        return
-      }
+      if (get().sessions.find((s) => s.host === session.host)) return
       set((state) => ({
         ...state,
         sessions: [...state.sessions, session],


### PR DESCRIPTION
ref https://github.com/paradigmxyz/rivet/pull/27#discussion_r1309601242 

which also changed the a session from a `Record` to an array. one nice thing bout `Record` is that new sessions replace old? since it's an array, noticed that kept adding the same host so it needs to be checked first