### PR TITLE
Add reset button to network configuration

### DIFF
--- a/src/hooks/useReset.ts
+++ b/src/hooks/useReset.ts
@@ -1,9 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import type { Client, ResetParameters } from 'viem'
-import { createQueryKey, queryClient } from '~/react-query'
+import { createQueryKey } from '~/react-query'
 import { useClient } from './useClient'
-import { getInfiniteBlocksQueryKey } from './useInfiniteBlocks'
-// import { getInfiniteBlocksQueryKey } from './useInfiniteBlocks'
 
 export const getAutomineQueryKey = createQueryKey<
   'reset',
@@ -16,9 +14,6 @@ export function useReset() {
   return useMutation({
     mutationFn: async (args?: ResetParameters) => {
       await client.reset(args)
-      //   await queryClient.invalidateQueries()
-      await queryClient.resetQueries({ queryKey: getInfiniteBlocksQueryKey() })
-      //   await queryClient.resetQueries({ queryKey: getInfiniteBlocksQueryKey() })
     },
   })
 }

--- a/src/hooks/useReset.ts
+++ b/src/hooks/useReset.ts
@@ -1,12 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
-import type { Client, ResetParameters } from 'viem'
-import { createQueryKey } from '~/react-query'
+import type { ResetParameters } from 'viem'
 import { useClient } from './useClient'
-
-export const getAutomineQueryKey = createQueryKey<
-  'reset',
-  [key: Client['key']]
->('reset')
 
 export function useReset() {
   const client = useClient()

--- a/src/hooks/useReset.ts
+++ b/src/hooks/useReset.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+import type { Client, ResetParameters } from 'viem'
+import { createQueryKey, queryClient } from '~/react-query'
+import { useClient } from './useClient'
+import { getInfiniteBlocksQueryKey } from './useInfiniteBlocks'
+// import { getInfiniteBlocksQueryKey } from './useInfiniteBlocks'
+
+export const getAutomineQueryKey = createQueryKey<
+  'reset',
+  [key: Client['key']]
+>('reset')
+
+export function useReset() {
+  const client = useClient()
+
+  return useMutation({
+    mutationFn: async (args?: ResetParameters) => {
+      await client.reset(args)
+      //   await queryClient.invalidateQueries()
+      await queryClient.resetQueries({ queryKey: getInfiniteBlocksQueryKey() })
+      //   await queryClient.resetQueries({ queryKey: getInfiniteBlocksQueryKey() })
+    },
+  })
+}

--- a/src/screens/network-config.tsx
+++ b/src/screens/network-config.tsx
@@ -61,9 +61,9 @@ export default function Network() {
         dismissable
         header="Network Configuration"
         footer={
-          <Stack gap="2px">
-            <Button onClick={handleResetFork}>Reset fork</Button>
-            <Button type="submit">Update</Button>
+          <Stack gap="8px">
+            <Button  type="submit">Update</Button>
+            <Button onClick={handleResetFork} variant='stroked red'>Reset fork</Button>
           </Stack>
         }
       >

--- a/src/screens/network-config.tsx
+++ b/src/screens/network-config.tsx
@@ -7,11 +7,13 @@ import * as chains from 'viem/chains'
 import { Container } from '~/components'
 import { Button, Input, Stack, Text } from '~/design-system'
 import { useDebounce } from '~/hooks/useDebounce'
+import { useReset } from '~/hooks/useReset'
 import { getClient } from '~/viem'
 import { useNetworkStore } from '~/zustand'
 
 export default function Network() {
   const { network, upsertNetwork, switchNetwork } = useNetworkStore()
+  const { mutate: reset } = useReset()
 
   type FormValues = {
     name: string
@@ -49,12 +51,23 @@ export default function Network() {
     navigate('/')
   })
 
+  const handleResetFork = async () => {
+    await reset({})
+  }
+
   return (
     <form onSubmit={onSubmit} style={{ height: '100%' }}>
       <Container
         dismissable
         header="Network Configuration"
-        footer={<Button type="submit">Update</Button>}
+        footer={
+          <Stack gap="2px">
+            <Button type="submit" onClick={handleResetFork}>
+              Reset fork
+            </Button>
+            <Button type="submit">Update</Button>
+          </Stack>
+        }
       >
         <Stack gap="20px">
           <Stack gap="12px">

--- a/src/screens/network-config.tsx
+++ b/src/screens/network-config.tsx
@@ -62,9 +62,7 @@ export default function Network() {
         header="Network Configuration"
         footer={
           <Stack gap="2px">
-            <Button type="submit" onClick={handleResetFork}>
-              Reset fork
-            </Button>
+            <Button onClick={handleResetFork}>Reset fork</Button>
             <Button type="submit">Update</Button>
           </Stack>
         }


### PR DESCRIPTION
closes #14 
- added a button to the bottom of the network configuration tab that resets an anvil fork
<img src="https://github.com/paradigmxyz/rivet/assets/15604932/4fb6d8dd-3123-4de1-92d9-1f0e5f37c27c" height=600px />


