### PR TITLE
Add loading state for updating ERC20 balances

### DIFF
--- a/src/design-system/components/Columns.tsx
+++ b/src/design-system/components/Columns.tsx
@@ -70,6 +70,7 @@ export const Columns = forwardRef<HTMLDivElement, ColumnsProps>(
 )
 
 type ColumnProps = {
+  alignHorizontal?: AlignHorizontal
   alignVertical?: AlignVertical
   width?: 'content' | keyof typeof styles.width
   children: ReactNode
@@ -98,10 +99,18 @@ function getColumnProps(node: NonNullable<ReactNode>): ColumnProps | null {
     : null
 }
 
-function PrivateColumn({ alignVertical, children, width }: ColumnProps) {
+function PrivateColumn({
+  alignHorizontal,
+  alignVertical,
+  children,
+  width,
+}: ColumnProps) {
   if (width) {
     return (
       <Box
+        alignItems={
+          alignHorizontal && alignHorizontalToJustifyContent[alignHorizontal]
+        }
         className={width !== 'content' ? styles.width[width] : undefined}
         display="flex"
         flexDirection="column"

--- a/src/hooks/useSetErc20Balance.ts
+++ b/src/hooks/useSetErc20Balance.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { useState } from 'react'
 import {
   type Address,
   BaseError,
@@ -38,9 +37,8 @@ const SLOT_VALUE_TO_CHECK = 1337_1337_1337_1337_1337_1337_1337_1337_1337n
  */
 export function useSetErc20Balance() {
   const client = useClient()
-  const [loading, setLoading] = useState(false)
 
-  const mutation = useMutation({
+  return useMutation({
     async mutationFn({
       tokenAddress,
       address,
@@ -133,16 +131,5 @@ export function useSetErc20Balance() {
         ]),
       })
     },
-    onMutate: () => {
-      setLoading(true)
-    },
-    onSuccess: () => {
-      setLoading(false)
-    },
   })
-
-  return {
-    ...mutation,
-    loading,
-  }
 }

--- a/src/hooks/useSetErc20Balance.ts
+++ b/src/hooks/useSetErc20Balance.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
 import {
   type Address,
   BaseError,
@@ -37,8 +38,9 @@ const SLOT_VALUE_TO_CHECK = 1337_1337_1337_1337_1337_1337_1337_1337_1337n
  */
 export function useSetErc20Balance() {
   const client = useClient()
+  const [loading, setLoading] = useState(false)
 
-  return useMutation({
+  const mutation = useMutation({
     async mutationFn({
       tokenAddress,
       address,
@@ -131,5 +133,16 @@ export function useSetErc20Balance() {
         ]),
       })
     },
+    onMutate: () => {
+      setLoading(true)
+    },
+    onSuccess: () => {
+      setLoading(false)
+    },
   })
+
+  return {
+    ...mutation,
+    loading,
+  }
 }

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -266,8 +266,8 @@ function BalanceInput({
   }, [balance, decimals])
 
   return (
-    <Box position="relative">
-      <Columns alignVertical="center" alignHorizontal="right" gap="4px">
+    <Box>
+      <Columns alignVertical="center" alignHorizontal="right">
         {isPending && (
           <Column width="1/5">
             <Spinner size="15px" />

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -267,9 +267,9 @@ function BalanceInput({
 
   return (
     <Box>
-      <Columns alignVertical="center" alignHorizontal="right">
+      <Columns alignVertical="center" alignHorizontal="right" gap="8px">
         {isPending && (
-          <Column width="1/5">
+          <Column alignHorizontal="right" width="1/5">
             <Spinner size="15px" />
           </Column>
         )}

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -111,7 +111,7 @@ function Tokens({ accountAddress }: { accountAddress: Address }) {
       </Bleed>
       {/* TODO: Handle empty state. */}
       {tokens[accountAddress]?.map((tokenAddress) => (
-        <TokenRow accountAddress={accountAddress} tokenAddress={tokenAddress} />
+        <TokenRow accountAddress={accountAddress} tokenAddress={tokenAddress} key={tokenAddress} />
       ))}
     </Inset>
   )

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -111,7 +111,11 @@ function Tokens({ accountAddress }: { accountAddress: Address }) {
       </Bleed>
       {/* TODO: Handle empty state. */}
       {tokens[accountAddress]?.map((tokenAddress) => (
-        <TokenRow accountAddress={accountAddress} tokenAddress={tokenAddress} key={tokenAddress} />
+        <TokenRow
+          accountAddress={accountAddress}
+          tokenAddress={tokenAddress}
+          key={tokenAddress}
+        />
       ))}
     </Inset>
   )
@@ -253,7 +257,7 @@ function BalanceInput({
   tokenAddress: Address
 }) {
   // TODO: Handle errors when setting balance.
-  const { mutate, loading } = useSetErc20Balance()
+  const { mutate, isPending } = useSetErc20Balance()
 
   const [value, setValue] = useState(formatUnits(balance, decimals))
 
@@ -263,7 +267,7 @@ function BalanceInput({
 
   return (
     <>
-      {loading ? (
+      {isPending ? (
         <Box style={{ textAlign: 'center' }}>
           <Spinner size="15px" />
         </Box>

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -5,6 +5,7 @@ import { type Address, formatUnits, isAddress, parseUnits } from 'viem'
 
 import { LabelledContent, TabsContent, TabsList, Tooltip } from '~/components'
 import * as Form from '~/components/form'
+import { Spinner } from '~/components/svgs'
 import {
   Bleed,
   Box,
@@ -252,7 +253,7 @@ function BalanceInput({
   tokenAddress: Address
 }) {
   // TODO: Handle errors when setting balance.
-  const { mutate } = useSetErc20Balance()
+  const { mutate, loading } = useSetErc20Balance()
 
   const [value, setValue] = useState(formatUnits(balance, decimals))
 
@@ -261,22 +262,30 @@ function BalanceInput({
   }, [balance, decimals])
 
   return (
-    <Input
-      onChange={(e) => setValue(e.target.value)}
-      onClick={(e) => e.stopPropagation()}
-      onBlur={(e) => {
-        const newValue = parseUnits(e.target.value as `${number}`, decimals)
-        if (newValue !== balance) {
-          mutate({
-            address,
-            tokenAddress,
-            value: newValue,
-          })
-        }
-      }}
-      height="24px"
-      style={{ textAlign: 'right' }}
-      value={value}
-    />
+    <>
+      {loading ? (
+        <Box style={{ textAlign: 'center' }}>
+          <Spinner size="15px" />
+        </Box>
+      ) : (
+        <Input
+          onChange={(e) => setValue(e.target.value)}
+          onClick={(e) => e.stopPropagation()}
+          onBlur={(e) => {
+            const newValue = parseUnits(e.target.value as `${number}`, decimals)
+            if (newValue !== balance) {
+              mutate({
+                address,
+                tokenAddress,
+                value: newValue,
+              })
+            }
+          }}
+          height="24px"
+          style={{ textAlign: 'right' }}
+          value={value}
+        />
+      )}
+    </>
   )
 }

--- a/src/screens/account-details.tsx
+++ b/src/screens/account-details.tsx
@@ -266,30 +266,36 @@ function BalanceInput({
   }, [balance, decimals])
 
   return (
-    <>
-      {isPending ? (
-        <Box style={{ textAlign: 'center' }}>
-          <Spinner size="15px" />
-        </Box>
-      ) : (
-        <Input
-          onChange={(e) => setValue(e.target.value)}
-          onClick={(e) => e.stopPropagation()}
-          onBlur={(e) => {
-            const newValue = parseUnits(e.target.value as `${number}`, decimals)
-            if (newValue !== balance) {
-              mutate({
-                address,
-                tokenAddress,
-                value: newValue,
-              })
-            }
-          }}
-          height="24px"
-          style={{ textAlign: 'right' }}
-          value={value}
-        />
-      )}
-    </>
+    <Box position="relative">
+      <Columns alignVertical="center" alignHorizontal="right" gap="4px">
+        {isPending && (
+          <Column width="1/5">
+            <Spinner size="15px" />
+          </Column>
+        )}
+        <Column width="4/5">
+          <Input
+            onChange={(e) => setValue(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onBlur={(e) => {
+              const newValue = parseUnits(
+                e.target.value as `${number}`,
+                decimals,
+              )
+              if (newValue !== balance) {
+                mutate({
+                  address,
+                  tokenAddress,
+                  value: newValue,
+                })
+              }
+            }}
+            height="24px"
+            style={{ textAlign: 'right' }}
+            value={value}
+          />
+        </Column>
+      </Columns>
+    </Box>
   )
 }


### PR DESCRIPTION
Addresses https://github.com/paradigmxyz/rivet/issues/62

Makes use of the existing `Spinner` component from `~/components/svgs` to create the following effect:

![Screen Shot 2023-09-14 at 8 53 06 pm](https://github.com/paradigmxyz/rivet/assets/2107693/6960babd-70b1-4ecf-9a52-a2d9d781b26e)

There was also a key error I noticed when interacting with this part of the tool (see below) which has also been resolved as part of this commit:

![Screen Shot 2023-09-14 at 8 51 44 pm](https://github.com/paradigmxyz/rivet/assets/2107693/f8dfb071-05c6-46c2-8a59-cc32d3491a88)
