### PR TITLE
Fix inpage bugs

### DIFF
--- a/src/entries/content/injectWallet.ts
+++ b/src/entries/content/injectWallet.ts
@@ -19,7 +19,7 @@ export async function injectWallet() {
     windowStorage.local.setItem('open', true)
 
   // Inject wallet elements
-  const container = injectContainer()
+  const container = await injectContainer()
   injectIframe({ container, extensionId })
 
   const handle = injectHandle({ container })
@@ -29,7 +29,7 @@ export async function injectWallet() {
 
 /////////////////////////////////////////////////////////////////////
 
-function injectContainer() {
+async function injectContainer() {
   const container = document.createElement('div')
   container.id = '__dev-wallet'
   container.style.width = '0px'
@@ -39,6 +39,14 @@ function injectContainer() {
   container.style.right = '0'
   container.style.border = 'none'
   container.style.zIndex = '2147483646'
+  container.style.transition = 'width 0.2s ease-in-out'
+  if (document.body === null) {
+    await new Promise<void>((resolve) => {
+      document.addEventListener('DOMContentLoaded', () => {
+        resolve()
+      })
+    })
+  }
   document.body.appendChild(container)
   return container
 }
@@ -99,7 +107,7 @@ function setupHandleListeners({
   })
 
   document.addEventListener('mouseup', () => {
-    container.style.pointerEvents = 'inherit'
+    container.style.pointerEvents = 'all'
     isDragging = false
   })
 }


### PR DESCRIPTION
Uses pointer events all instead of inherit in case of in page dialogs. See Tamagui Dialogs.

Uses a promise to inject the container since the body [may be null at document start](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#:~:text=document.readyState%20property.-,document_start,any%20other%20DOM%20is%20constructed%20or%20any%20other%20script%20is%20run.,-document_end). 

--- 

Thank you for putting out this awesome tool. Literally 10x's dev with frontend dapps. I would love to see an option where Rivet is not limited to inpage but could be controlled via popup or new tab.