### PR TITLE
fix: add ellipsis for overflowing rpc labels

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -293,7 +293,7 @@ function RpcUrl() {
           borderRadius="round"
           style={{ minWidth: 8, minHeight: 8 }}
         />
-        <Text size="12px" wrap={false} width="full">
+        <Text size="12px" wrap={false} width="full" style={{overflow: "hidden", textOverflow: "ellipsis"}}>
           {network.rpcUrl.replace(/https?:\/\//, '')}
         </Text>
       </Inline>

--- a/src/screens/networks.tsx
+++ b/src/screens/networks.tsx
@@ -166,6 +166,7 @@ function NetworkRow({
                   color={data ? 'text' : 'text/tertiary'}
                   size="12px"
                   wrap={false}
+                  style={{overflow: "hidden", textOverflow: "ellipsis"}}
                 >
                   {network.rpcUrl.replace(/https?:\/\//, '')}
                 </Text>


### PR DESCRIPTION
Fixed a visual overflow when the RPC is longer than "localhost:5137", especially useful when using Rivet to modify Tenderly forks or reading state directly from an RPC provider instead of forking with Anvil first. Modification below:

Old:
<img width="417" alt="Screenshot 2023-12-06 at 6 57 55 PM" src="https://github.com/paradigmxyz/rivet/assets/45244108/9c9bf6ef-d5d2-46eb-ab46-7c845406f202">
New:
<img width="417" alt="Screenshot 2023-12-06 at 6 55 11 PM" src="https://github.com/paradigmxyz/rivet/assets/45244108/91edcdd1-a717-4728-98ef-d42ce9c598fa">
