### PR TITLE
fix: set inpage ouptut to iife

### DIFF
--- a/vite.config.inpage.ts
+++ b/vite.config.inpage.ts
@@ -22,7 +22,7 @@ export default defineConfig({
           name: 'try-catch',
           generateBundle(_, context) {
             Object.values(context).forEach((bundle: any) => {
-              bundle.code = `try{${bundle.code}}catch{}`
+              bundle.code = `(function(){try{${bundle.code}}catch{}}())`
             })
           },
         },


### PR DESCRIPTION
resolve #103

there's a `var _=...` in the `inpage.js` output and it conflicts with google map

this PR wraps the output in a self exec function to avoid that

for unknown reason update `rollupOptions.output.format` to `iife` does not work